### PR TITLE
Add getters for FSRSReview and MemoryState properties

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,9 @@ issue_tracker: https://github.com/open-spaced-repetition/fsrs-rs-dart/issues
 environment:
   sdk: '>=3.3.0 <4.0.0'
 dependencies:
-  lints: ^2.0.1
+  lints: ^5.0.0
   flutter_rust_bridge: 2.9.0
-  freezed_annotation: ^2.2.0
+  freezed_annotation: ^3.0.0
   collection: ^1.18.0
 dev_dependencies:
   test: ^1.21.4

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,21 @@
+[target.aarch64-linux-android]
+ar = "llvm-ar"
+linker = "aarch64-linux-android23-clang"
+
+[target.armv7-linux-androideabi]
+ar = "llvm-ar"
+linker = "armv7a-linux-androideabi23-clang"
+
+[target.i686-linux-android]
+ar = "llvm-ar"
+linker = "i686-linux-android23-clang"
+
+[target.x86_64-linux-android]
+ar = "llvm-ar"
+linker = "x86_64-linux-android23-clang"
+
+[env]
+CC_aarch64_linux_android = "aarch64-linux-android23-clang"
+CC_armv7_linux_androideabi = "armv7a-linux-androideabi23-clang"
+CC_i686_linux_android = "i686-linux-android23-clang"
+CC_x86_64_linux_android = "x86_64-linux-android23-clang"

--- a/rust/build-android.sh
+++ b/rust/build-android.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Set NDK path - adjust this to your NDK installation path
+export NDK_HOME="$HOME/Android/Sdk/ndk/29.0.13113456"
+export PATH="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+
+# Build for all Android targets
+cargo build --release --target aarch64-linux-android
+cargo build --release --target armv7-linux-androideabi
+cargo build --release --target i686-linux-android
+cargo build --release --target x86_64-linux-android

--- a/rust/build-apple.sh
+++ b/rust/build-apple.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Install required toolchains
+rustup target add x86_64-apple-darwin
+rustup target add aarch64-apple-darwin
+rustup target add aarch64-apple-ios
+rustup target add x86_64-apple-ios
+rustup target add aarch64-apple-ios-sim
+
+# Check for Xcode installation (macOS only)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if ! xcode-select -p &> /dev/null; then
+        echo "Xcode not found. Please install Xcode from the App Store."
+        exit 1
+    fi
+fi
+
+# Build for macOS targets
+cargo build --release --target x86_64-apple-darwin
+cargo build --release --target aarch64-apple-darwin
+
+# Build for iOS targets
+cargo build --release --target aarch64-apple-ios
+cargo build --release --target x86_64-apple-ios
+cargo build --release --target aarch64-apple-ios-sim

--- a/rust/build-desktop.sh
+++ b/rust/build-desktop.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Install required toolchains
+rustup target add x86_64-unknown-linux-gnu
+rustup target add aarch64-unknown-linux-gnu
+rustup target add x86_64-pc-windows-gnu
+
+# Install cross-compilation toolchains
+echo "Installing cross-compilation toolchains..."
+sudo apt-get update
+sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+# Install Windows toolchain dependencies
+if ! command -v x86_64-w64-mingw32-gcc &> /dev/null; then
+    echo "Installing mingw-w64..."
+    sudo apt-get install -y mingw-w64
+fi
+
+# Set up cross-compilation environment variables
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-aarch64 -L /usr/aarch64-linux-gnu"
+
+# Build for Linux targets
+echo "Building for Linux targets..."
+cargo build --release --target x86_64-unknown-linux-gnu
+cargo build --release --target aarch64-unknown-linux-gnu
+
+# Build for Windows targets (GNU only, skipping MSVC due to dart-sys compatibility)
+echo "Building for Windows targets..."
+cargo build --release --target x86_64-pc-windows-gnu
+
+# Note: Skipping aarch64-pc-windows-msvc due to dart-sys compatibility issues
+echo "Note: aarch64-pc-windows-msvc target skipped due to dart-sys compatibility issues"


### PR DESCRIPTION
## Problem
Currently, there's no way to directly access the properties of `FSRSReview` (rating, delta_t) and `MemoryState` (stability, difficulty) through the API. The only way to access these values is by parsing the string representation, which is fragile and could break if the string format changes.

## Solution
Add proper getters to access these properties directly:

- `FSRSReview`:
  - `rating()`: returns the rating value
  - `delta_t()`: returns the delta_t value

- `MemoryState`:
  - `stability()`: returns the stability value
  - `difficulty()`: returns the difficulty value

## Benefits
1. Type-safe access to properties
2. More robust serialization
3. No need to parse strings
4. Better API usability

## Notes
I have also updated the dependencies of freezed_annotation and lints to the latest major versions. Freezed doesn't seem to be used anywhere so we could probably even remove the 2 dep. As for lints, well, this is self-explanatory.
